### PR TITLE
bug(prune): handle OSes on whom fs.stats hasn't birthTime

### DIFF
--- a/lib/prune-cache.js
+++ b/lib/prune-cache.js
@@ -21,7 +21,8 @@ function pruneCache(npmPkgrCache, cb) {
       monthAgo.setMonth(monthAgo.getMonth() - 1);
 
       var oldCache = results.reduce(function (res, curr, idx) {
-        return (curr.birthtime.getTime() - monthAgo < 0) ?
+        var creationTime = curr.birthtime || curr.mtime;
+        return (creationTime.getTime() - monthAgo < 0) ?
           res.concat([ cacheFolders[idx] ]) : res;
       }, []);
 


### PR DESCRIPTION
The new prune command uses fs.stats.birthtime

OSes don't all have birthtime (https://github.com/nodejs/node/issues/2222)

Add a fallback to mtime in this case http://www.linux-faqs.info/general/difference-between-mtime-ctime-and-atime

