### PR TITLE
bug: fix symlinks and tests on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ function npmPkgr(opts, cb) {
         get = fs.symlink.bind(fs,
           path.join(cachedir, 'node_modules'),
           path.join(opts.cwd, 'node_modules'),
-          'dir'
+          /^win/.test(process.platform) ? 'junction' : 'dir'
         )
       }
 

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -6,12 +6,13 @@ fs = require('fs');
 path = require('path');
 shell = require('shelljs');
 test = require('prova');
+rimraf = require('rimraf');
 
 baseProject = path.join(__dirname, 'example-project');
 npmPkgr = require('../');
 
 clean = function clean() {
-  shell.exec('rm -rf ~/.npm-pkgr');
+  rimraf.sync(path.join(process.env.HOME, '.npm-pkgr'));
   shell.exec('npm cache clean');
 };
 

--- a/test/spec/npmrc.js
+++ b/test/spec/npmrc.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var EOL = require('os').EOL;
 require('../bootstrap');
 
 test('npmrc should be copied', function(t) {
@@ -14,7 +15,7 @@ test('npmrc should be copied', function(t) {
     t.error(err);
     console.log('ok');
     var npmrc = fs.readFileSync(path.join(tmpProjectDir, '.npmrc'), 'utf8');
-    t.equal(npmrc, '# npmrc\n');
+    t.equal(npmrc, '# npmrc' + EOL);
     t.end();
   }
 });


### PR DESCRIPTION
Testing on Windows now works on Git Bash (so most Unix commands can still be used). Main problem in tests was that long paths can be created but not removed - `rimraf` somehow manages to do this.

Functionally the main improvement is that we create a junction on Windows, so that we don't have to use the copy strategy, which is a lot slower.