### PR TITLE
Write npm output

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,31 @@ Use `npm-pkgr` instead of `npm install` and you are done.
 npm-pkgr
 ```
 
-Hashes and find the latest build corresponding to `package.json` and `npm-shrinkwrap.json`.
+Hashes and finds the latest build corresponding to `package.json` and `npm-shrinkwrap.json`.
 
 ```shell
 npm-pkgr --production
 ```
 
-Hashes and fin the latest build corresponding to `npm-shrinkwrap.json`.
+Hashes and finds the latest build corresponding to `npm-shrinkwrap.json`.
 
-Every flag passed to `npm-pkgr` is then passed down to `npm` command.
+```shell
+npm-pkgr --show-npm-output
+```
+
+Displays `npm`'s output, if `npm install` is run.
+
+Every other flag passed to `npm-pkgr` is passed down to the `npm install` command.
 
 ## Cache folder
 
-The cache folder used by `npm-pkgr` is `~/.npm-pkgr` for current user.
+The cache folder used by `npm-pkgr` is `~/.npm-pkgr` for the current user.
 
 ```shell
 npm-pkgr prune
 ```
 
-Removes older than a month cache folders (into your `~/.npm-pkgr` folder)
+Removes cache folders older than a month (in your `~/.npm-pkgr` folder)
 
 ## Debug
 
@@ -67,7 +73,7 @@ You can also get a full copy of the `~/.npm-pkgr/$hash/node_modules`.
 npm-pkgr --strategy=copy
 ```
 
-Carefull, if you `--strategy copy`, you will end up installing the `copy package`
+Careful, if you `--strategy copy`, you will end up installing the `copy package`
 
 ## features
 

--- a/cli.js
+++ b/cli.js
@@ -11,7 +11,7 @@ npmPkgr({
   cwd: process.cwd(),
   args: process.argv.slice(2),
   strategy: argv.strategy,
-  showNpmOutput: argv['show-npm-output']
+  npmIo: argv['show-npm-output'] ? 'inherit' : null
 }, end);
 
 function end(err, res) {

--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,8 @@ if (argv.version) {
 npmPkgr({
   cwd: process.cwd(),
   args: process.argv.slice(2),
-  strategy: argv.strategy
+  strategy: argv.strategy,
+  showNpmOutput: argv['show-npm-output']
 }, end);
 
 function end(err, res) {

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ function npmPkgr(opts, cb) {
       npmUsed = true;
       async.series([
         lazyCopy.bind(null, files, cachedir),
-        installNpm.bind(null, cachedir, { args: opts.args, showNpmOutput: opts.showNpmOutput }),
+        installNpm.bind(null, cachedir, { args: opts.args, npmIo: opts.npmIo }),
         lockfile.unlock.bind(lockfile, cachelock),
         getNodeModules
       ], end);

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ function npmPkgr(opts, cb) {
 
   opts.args = opts.args || [];
 
-  var npmArgs = opts.args.join(' ');
   var npmUsed;
   var files = ['package.json', 'npm-shrinkwrap.json', '.npmrc'].map(realPath(opts.cwd));
   var production = opts.args.indexOf('--production') !== -1;
@@ -107,7 +106,7 @@ function npmPkgr(opts, cb) {
       npmUsed = true;
       async.series([
         lazyCopy.bind(null, files, cachedir),
-        installNpm.bind(null, cachedir, npmArgs),
+        installNpm.bind(null, cachedir, { args: opts.args, showNpmOutput: opts.showNpmOutput }),
         lockfile.unlock.bind(lockfile, cachelock),
         getNodeModules
       ], end);

--- a/lib/install-npm.js
+++ b/lib/install-npm.js
@@ -9,7 +9,7 @@ var spawn = require('child_process').spawn;
 function installNpm(to, options, cb) {
   var npmArgs = ['install'].concat(options.args);
   console.log('start `npm %s`', npmArgs.join(' '));
-  const npmInstall = spawn('npm', npmArgs, {
+  var npmInstall = spawn('npm', npmArgs, {
     cwd: to,
     stdio: options.showNpmOutput ? 'inherit' : 'ignore'
   });

--- a/lib/install-npm.js
+++ b/lib/install-npm.js
@@ -1,20 +1,25 @@
 module.exports = installNpm;
 
 /**
- * `npm install` in a dir, using cp.exec
+ * `npm install` in a dir, using cp.spawn
  */
 
-var exec = require('child_process').exec;
+var spawn = require('child_process').spawn;
 
-function installNpm(to, args, cb) {
-  console.log('start `npm install %s`', args);
-  exec('npm install ' + args, {
+function installNpm(to, options, cb) {
+  var npmArgs = ['install'].concat(options.args);
+  console.log('start `npm %s`', npmArgs.join(' '));
+  const npmInstall = spawn('npm', npmArgs, {
     cwd: to,
-    maxBuffer: 20*1024*1024
-  }, done);
+    stdio: options.showNpmOutput ? 'inherit' : 'ignore'
+  });
 
-  function done(err, stdout, stderr) {
-    console.log('end `npm install %s`', args);
-    cb(err);
-  }
+  npmInstall.on('close', function(code) {
+    if (options.showNpmOutput) {
+      console.log('end `npm %s`, exit code: %d', npmArgs.join(' '), code);
+    } else {
+      console.log('end `npm %s`', npmArgs.join(' '));
+    }
+    cb(code ? new Error('Error running npm: ' + code) : null);
+  });
 }

--- a/lib/install-npm.js
+++ b/lib/install-npm.js
@@ -11,15 +11,11 @@ function installNpm(to, options, cb) {
   console.log('start `npm %s`', npmArgs.join(' '));
   var npmInstall = spawn('npm', npmArgs, {
     cwd: to,
-    stdio: options.showNpmOutput ? 'inherit' : 'ignore'
+    stdio: options.npmIo ? options.npmIo : 'ignore'
   });
 
   npmInstall.on('close', function(code) {
-    if (options.showNpmOutput) {
-      console.log('end `npm %s`, exit code: %d', npmArgs.join(' '), code);
-    } else {
-      console.log('end `npm %s`', npmArgs.join(' '));
-    }
+    console.log('end `npm %s`', npmArgs.join(' '));
     cb(code ? new Error('Error running npm: ' + code) : null);
   });
 }

--- a/test/spec/cli.js
+++ b/test/spec/cli.js
@@ -1,0 +1,59 @@
+require('../bootstrap');
+
+var process = require('process');
+var spawn = require('child_process').spawn;
+
+test('cli: clean run', function(t) {
+  clean();
+
+  var tmpProjectDir = getTmpProject();
+
+  run(tmpProjectDir, [], function(err) {
+    t.end(err);
+  });
+});
+
+test('cli: failing run', testWithFailure);
+
+test('cli: failing run with npm output', function(t) {
+  testWithFailure(t, ['--show-npm-output'])
+});
+
+function testWithFailure(t, args) {
+  args = args || [];
+
+  clean();
+
+  var tmpProjectDir = getTmpProject();
+
+  async.series([
+    setupNpmFailure.bind(null, tmpProjectDir),
+    run.bind(null, tmpProjectDir, args)
+  ], function(err) {
+    t.ok(err, 'there should be an error from calling npm-pkgr');
+    t.equal(err.message, '1', 'the process should have exited with code 1');
+    t.end();
+  });
+}
+
+function setupNpmFailure(projectDir, callback) {
+  var shrinkwrap = path.join(projectDir, 'npm-shrinkwrap.json');
+
+  updateJson(shrinkwrap, {
+    dependencies: {
+      // this should fail npm install
+      dslakdslakdas: 'foiwqufwoqiufqw'
+    }
+  })(callback);
+}
+
+function run(projectDir, args, callback) {
+  var npmPkgrCli = path.join(__dirname, '..', '..', 'cli.js');
+  var nodeCmd = process.argv[0];
+
+  var child = spawn(nodeCmd, [npmPkgrCli].concat(args), {stdio: 'inherit', cwd: projectDir});
+
+  child.on('close', function(code) {
+    callback(code ? new Error(code) : null);
+  });
+}

--- a/test/spec/cli.js
+++ b/test/spec/cli.js
@@ -37,12 +37,11 @@ function testWithFailure(t, args) {
 }
 
 function setupNpmFailure(projectDir, callback) {
-  var shrinkwrap = path.join(projectDir, 'npm-shrinkwrap.json');
+  var pkg = path.join(projectDir, 'package.json');
 
-  updateJson(shrinkwrap, {
-    dependencies: {
-      // this should fail npm install
-      dslakdslakdas: 'foiwqufwoqiufqw'
+  updateJson(pkg, {
+    scripts: {
+      preinstall: 'There\'s no way this will work'
     }
   })(callback);
 }

--- a/test/spec/npm-show-output.js
+++ b/test/spec/npm-show-output.js
@@ -1,0 +1,29 @@
+require('../bootstrap');
+
+test('Capture npm output', function(t) {
+  clean();
+
+  var tmpProjectDir = getTmpProject();
+
+  // The `npmIo` option is passed to child_process.spawn, which needs a file descriptor, so use a
+  // tmp file. In this test we don't care if npm writes to stdout or stderr, that is up to npm to
+  // decide.
+  var npmOutPath = path.join(tmpProjectDir, 'npm-out.log');
+  var enc = 'utf8';
+  var npmOut = fs.createWriteStream(npmOutPath, enc);
+
+  npmPkgr({
+    cwd: tmpProjectDir,
+    npmIo: [null, npmOut, npmOut] // no need for stdin
+  }, end);
+
+  function end(err, result) {
+    t.error(err);
+    t.ok(result.npm, 'npm should have been used');
+
+    var npmOutText = fs.readFileSync(npmOutPath, enc);
+
+    t.assert(npmOutText.length > 0, 'Some npm output should have been written');
+    t.end();
+  }
+});


### PR DESCRIPTION
As discussed in #17.

Unfortunately it is hard to write a test for this. I tried something like https://gist.github.com/pguillory/729616, but that does not catch `npm`'s output -- ideal would be to capture the child process's output, but that would be quite some work.