### PR TITLE
Using node_shrinkwrap for npm install if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ npm-pkgr --strategy=copy
 
 Careful, if you `--strategy copy`, you will end up installing the `copy package`
 
+## symlinks
+
+Use the `--symlinks` option if you wish make some files or folders from your project available during `npm install`.
+
+For example if your project includes a local `.cache` folder for the npm cache and a `node_shrinkwrap` folder for pre-packaged modules, then you can use the following command to make those resources available when npm-pkgr runs `npm install`:
+
+```shell
+npm-pkgr --symlinks=.cache,node_shrinkwrap
+```
+
 ## features
 
 * insanely fast `npm install` if already done

--- a/cli.js
+++ b/cli.js
@@ -9,10 +9,27 @@ if (argv.version) {
 
 npmPkgr({
   cwd: process.cwd(),
-  args: process.argv.slice(2),
+  args: process.argv.slice(2).filter(removeArgs.bind(null, {
+    '--strategy': { expectsValue: false },
+    '--show-npm-output': { expectsValue: false },
+    '--symlinks': { expectsValue: true }
+  })),
   strategy: argv.strategy,
-  npmIo: argv['show-npm-output'] ? 'inherit' : null
+  npmIo: argv['show-npm-output'] ? 'inherit' : null,
+  symlinks: argv.symlinks ? argv.symlinks.split(',') : null
 }, end);
+
+
+function removeArgs(argsToRemove, argName, argIndex, argsArr) {
+  var removeCurrentArg = typeof argsToRemove[argName] !== 'undefined';
+  var removePreviousArg = (
+    argIndex > 0 &&
+    argName.indexOf('--') !== 0 &&
+    typeof argsToRemove[argsArr[argIndex - 1]] !== 'undefined' &&
+    argsToRemove[argsArr[argIndex - 1]].expectsValue === true
+  );
+  return !(removeCurrentArg || removePreviousArg);
+}
 
 function end(err, res) {
   if (err) {

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var rimraf = require('rimraf');
 var computeHash = require('./lib/compute-hash');
 var installNpm = require('./lib/install-npm');
 var lazyCopy = require('./lib/lazy-copy');
+var symlink = require('./lib/symlink');
 var realPath = require('./lib/real-path');
 var pruneCache = require('./lib/prune-cache');
 
@@ -22,6 +23,7 @@ function npmPkgr(opts, cb) {
 
   var npmUsed;
   var files = ['package.json', 'npm-shrinkwrap.json', '.npmrc'].map(realPath(opts.cwd));
+  var symlinks = ['node_shrinkwrap'].map(realPath(opts.cwd));
   var production = opts.args.indexOf('--production') !== -1;
   var npmPkgrCache = path.join(process.env.HOME, '.npm-pkgr');
   var lockOpts = {
@@ -106,6 +108,7 @@ function npmPkgr(opts, cb) {
       npmUsed = true;
       async.series([
         lazyCopy.bind(null, files, cachedir),
+        symlink.bind(null, symlinks, cachedir),
         installNpm.bind(null, cachedir, { args: opts.args, npmIo: opts.npmIo }),
         lockfile.unlock.bind(lockfile, cachelock),
         getNodeModules

--- a/index.js
+++ b/index.js
@@ -20,10 +20,11 @@ function npmPkgr(opts, cb) {
   console.log('starting npm-pkgr with opts: %j', opts);
 
   opts.args = opts.args || [];
+  opts.symlinks = opts.symlinks || [];
 
   var npmUsed;
   var files = ['package.json', 'npm-shrinkwrap.json', '.npmrc'].map(realPath(opts.cwd));
-  var symlinks = ['node_shrinkwrap'].map(realPath(opts.cwd));
+  var symlinks = opts.symlinks.map(realPath(opts.cwd));
   var production = opts.args.indexOf('--production') !== -1;
   var npmPkgrCache = path.join(process.env.HOME, '.npm-pkgr');
   var lockOpts = {

--- a/index.js
+++ b/index.js
@@ -150,7 +150,8 @@ function npmPkgr(opts, cb) {
       cb(null, {
         dir: opts.cwd,
         node_modules: destination,
-        npm: npmUsed
+        npm: npmUsed,
+        cachedir: cachedir
       });
     }
 

--- a/lib/symlink.js
+++ b/lib/symlink.js
@@ -1,0 +1,32 @@
+module.exports = symlink;
+
+function symlink(files, to, cb) {
+  var debug = require('debug')('npm-pkgr:symlink');
+
+  var async = require('contra');
+  var path = require('path');
+
+  async.waterfall([
+    filter.bind(null, files),
+    symlinkFiltered
+  ], cb);
+
+  function filter(files, cb) {
+    var fs = require('fs');
+    async.filter(files, fileExists, cb);
+  }
+
+  function symlinkFiltered(files) {
+    debug('symlinking %j to %s', files, to);
+
+    async.each(files, function createSymlink(file) {
+      var fs = require('fs');
+      fs.symlink(file, path.join(to, path.basename(file)), cb);
+    }, cb);
+  }
+}
+
+function fileExists(file, cb) {
+  var fs = require('fs');
+  fs.exists(file, cb.bind(null, null));
+}

--- a/test/spec/symlinks.js
+++ b/test/spec/symlinks.js
@@ -1,0 +1,24 @@
+var mock = require('mock-fs');
+
+test('--symlinks path1,path2', function(t) {
+  clean();
+
+  var tmpProjectDir = getTmpProject();
+  
+  shell.mkdir(path.join(tmpProjectDir, 'path1'));
+  shell.mkdir(path.join(tmpProjectDir, 'path2'));
+
+  npmPkgr({
+    cwd: tmpProjectDir,
+    symlinks: ['path1', 'path2']
+  }, end);
+
+  function end(err, result) {
+    t.error(err);
+    
+    t.ok(shell.test('-L', path.join(result.cachedir, 'path1')), 'it should have created a symbolic link for path1');
+    t.ok(shell.test('-L', path.join(result.cachedir, 'path2')), 'it should have created a symbolic link for path2');
+
+    t.end();
+  }
+});


### PR DESCRIPTION
Hi! with this pull request I added code to symlink the `node_shrinkwrap` folder to the `cachedir`, if it exist. This allows npm-pkgr to work together with [shrinkpack](https://www.npmjs.com/package/shrinkpack) to prevent network activity when running npm install.