### PR TITLE
Fix running `npm install` on Windows

### DIFF
--- a/lib/install-npm.js
+++ b/lib/install-npm.js
@@ -7,9 +7,10 @@ module.exports = installNpm;
 var spawn = require('child_process').spawn;
 
 function installNpm(to, options, cb) {
+  var npmCmd = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
   var npmArgs = ['install'].concat(options.args);
   console.log('start `npm %s`', npmArgs.join(' '));
-  var npmInstall = spawn('npm', npmArgs, {
+  var npmInstall = spawn(npmCmd, npmArgs, {
     cwd: to,
     stdio: options.npmIo ? options.npmIo : 'ignore'
   });


### PR DESCRIPTION
`child_process.spawn` needs the extension on Windows, see
nodejs/node-v0.x-archive#2318.

Looks like I broke this myself in 26b492a979a97907c312e7d00df84e89cedd9474, sorry!