### PR TITLE
Add option - custom cachepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ For example if your project includes a local `.cache` folder for the npm cache a
 npm-pkgr --symlinks=.cache,node_shrinkwrap
 ```
 
+## cachepath
+
+Use the `--cachepath` option if you want use a specific folder for the cache folder.
+
+```shell
+npm-pkgr --cachepath=/data/node-vXXX/.npm-pkgr
+```
+
 ## features
 
 * insanely fast `npm install` if already done

--- a/cli.js
+++ b/cli.js
@@ -12,11 +12,13 @@ npmPkgr({
   args: process.argv.slice(2).filter(removeArgs.bind(null, {
     '--strategy': { expectsValue: false },
     '--show-npm-output': { expectsValue: false },
-    '--symlinks': { expectsValue: true }
+    '--symlinks': { expectsValue: true },
+	'--cachepath': { expectsValue: true }
   })),
   strategy: argv.strategy,
   npmIo: argv['show-npm-output'] ? 'inherit' : null,
-  symlinks: argv.symlinks ? argv.symlinks.split(',') : null
+  symlinks: argv.symlinks ? argv.symlinks.split(',') : null,
+  cachepath: argv.cachepath ? argv.cachepath.split(',') : null
 }, end);
 
 

--- a/index.js
+++ b/index.js
@@ -21,12 +21,17 @@ function npmPkgr(opts, cb) {
 
   opts.args = opts.args || [];
   opts.symlinks = opts.symlinks || [];
+  opts.cachepath = opts.cachepath || [];
 
   var npmUsed;
   var files = ['package.json', 'npm-shrinkwrap.json', '.npmrc'].map(realPath(opts.cwd));
   var symlinks = opts.symlinks.map(realPath(opts.cwd));
   var production = opts.args.indexOf('--production') !== -1;
-  var npmPkgrCache = path.join(process.env.HOME, '.npm-pkgr');
+  var npmPkgrCache =  opts.cachepath[0] ||  path.join(process.env.HOME, '.npm-pkgr');
+  
+  
+  console.log('npmPkgrCache', npmPkgrCache);
+  
   var lockOpts = {
     wait: 2 * 1000,
     stale: 60 * 1000,

--- a/index.js
+++ b/index.js
@@ -29,9 +29,6 @@ function npmPkgr(opts, cb) {
   var production = opts.args.indexOf('--production') !== -1;
   var npmPkgrCache =  opts.cachepath[0] ||  path.join(process.env.HOME, '.npm-pkgr');
   
-  
-  console.log('npmPkgrCache', npmPkgrCache);
-  
   var lockOpts = {
     wait: 2 * 1000,
     stale: 60 * 1000,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-pkgr",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Cache `npm install` results by hashing dependencies",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I can't use /home/{user]/.npm-pkgr for my build.
I added an option "cachepath" to custom this path.